### PR TITLE
0.6.4 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "mui-data-grid"
 packages = [{ include = "mui", from = "src" }]
 readme = "README.md"
 repository = "https://github.com/kkirsche/mui-data-grid"
-version = "0.6.3"
+version = "0.6.4"
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4"

--- a/src/mui/v5/integrations/sqlalchemy/filter/apply_items.py
+++ b/src/mui/v5/integrations/sqlalchemy/filter/apply_items.py
@@ -1,8 +1,7 @@
 """The apply_model module is responsible for applying a GridSortModel to a query."""
-from collections.abc import Collection
 from datetime import datetime
 from operator import eq, ge, gt, le, lt, ne
-from typing import Any, Callable, Optional, TypeVar, cast
+from typing import Any, Callable, Collection, Optional, TypeVar, cast
 
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Query


### PR DESCRIPTION
* fix: broken release on Python <=3.8 due to use of `collections.abc.Collection` instead of `typing.Collection`