### PR TITLE
feat: add explicit model format support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "mui-data-grid"
 packages = [{ include = "mui", from = "src" }]
 readme = "README.md"
 repository = "https://github.com/kkirsche/mui-data-grid"
-version = "0.6.7"
+version = "0.6.8"
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4"

--- a/src/mui/v5/integrations/flask/filter/model.py
+++ b/src/mui/v5/integrations/flask/filter/model.py
@@ -3,14 +3,20 @@
 Supports parsing a GridFilterModel from Flask's request.args
 """
 from flask import request
+from functools import partial
+from typing_extensions import Literal
 
 from mui.v5.grid.filter import GridFilterModel
 
 
 def get_grid_filter_model_from_request(
-    key: str = "filter_model",
+    key: str = "filter_model", model_format: Literal["json"] = "json"
 ) -> GridFilterModel:
     """Retrieves a GridFilterModel from request.args.
+
+    Currently, this only supports a JSON encoded model, but in the future the plan is
+    to write a custom querystring parser to support nested arguments as JavaScript
+    libraries like Axios create out of the box.
 
     Args:
         key (str): The key in the request args where the filter model should be parsed
@@ -18,6 +24,7 @@ def get_grid_filter_model_from_request(
 
     Raises:
         ValidationError: Raised when an invalid type was received.
+        ValueError: Raised when an invalid model format was received.
 
     Returns:
         GridFilterModel: The parsed filter model, if found. If no filter model is
@@ -26,6 +33,9 @@ def get_grid_filter_model_from_request(
     # get swallows `KeyError` and `ValueError`, which is why we don't allow this to
     # raise an exception
     # https://github.com/pallets/werkzeug/blob/main/src/werkzeug/datastructures.py#L919
-    return request.args.get(
-        key=key, default=GridFilterModel(), type=GridFilterModel.parse_raw
-    )
+    if model_format == "json":
+        # https://pydantic-docs.helpmanual.io/usage/models/#helper-functions
+        return request.args.get(
+            key=key, default=GridFilterModel(), type=GridFilterModel.parse_raw
+        )
+    raise ValueError(f"Unsupported model format: {model_format}")

--- a/src/mui/v5/integrations/flask/request.py
+++ b/src/mui/v5/integrations/flask/request.py
@@ -2,6 +2,7 @@
 
 Supports parsing the filter, pagination, and sort models from Flask's request.args."""
 from typing import Optional
+from typing_extensions import Literal
 
 from mui.v5.grid.request import RequestGridModels
 from mui.v5.integrations.flask.filter.model import get_grid_filter_model_from_request
@@ -15,6 +16,8 @@ def get_grid_models_from_request(
     sort_model_key: str = "sort_model[]",
     filter_model_key: str = "filter_model",
     pagination_model_key: Optional[str] = None,
+    sort_model_format: Literal["json"] = "json",
+    filter_model_format: Literal["json"] = "json",
 ) -> RequestGridModels:
     """Parses the filter, sort, and pagination models from the request.
 
@@ -44,8 +47,12 @@ def get_grid_models_from_request(
         RequestGridModels: The located grid models.
     """
     return RequestGridModels(
-        filter_model=get_grid_filter_model_from_request(key=filter_model_key),
-        sort_model=get_grid_sort_model_from_request(key=sort_model_key),
+        filter_model=get_grid_filter_model_from_request(
+            key=filter_model_key, model_format=filter_model_format
+        ),
+        sort_model=get_grid_sort_model_from_request(
+            key=sort_model_key, model_format=sort_model_format
+        ),
         pagination_model=get_grid_pagination_model_from_request(
             key=pagination_model_key
         ),

--- a/src/mui/v5/integrations/flask/sort/model.py
+++ b/src/mui/v5/integrations/flask/sort/model.py
@@ -4,12 +4,19 @@ Supports parsing a GridSortModel from Flask's request.args
 """
 from flask import request
 from pydantic import parse_obj_as
+from typing_extensions import Literal
 
 from mui.v5.grid.sort import GridSortItem, GridSortModel
 
 
-def get_grid_sort_model_from_request(key: str = "sorl_model[]") -> GridSortModel:
+def get_grid_sort_model_from_request(
+    key: str = "sorl_model[]", model_format: Literal["json"] = "json"
+) -> GridSortModel:
     """Retrieves a GridSortModel from request.args.
+
+    Currently, this only supports a JSON encoded model, but in the future the plan is
+    to write a custom querystring parser to support nested arguments as JavaScript
+    libraries like Axios create out of the box.
 
     Args:
         key (str): The key in the request args where the sort model should be parsed
@@ -17,11 +24,14 @@ def get_grid_sort_model_from_request(key: str = "sorl_model[]") -> GridSortModel
 
     Raises:
         ValidationError: Raised when an invalid type was received.
+        ValueError: Raised when an invalid model format was received.
 
     Returns:
         GridSortModel: The parsed sort model.
     """
     # getlist returns [] as a default when the key doesn't exist
     # https://github.com/pallets/werkzeug/blob/main/src/werkzeug/datastructures.py#L395
-    value = request.args.getlist(key=key, type=GridSortItem.parse_raw)
-    return parse_obj_as(GridSortModel, value)
+    if model_format == "json":
+        value = request.args.getlist(key=key, type=GridSortItem.parse_raw)
+        return parse_obj_as(GridSortModel, value)
+    raise ValueError(f"Invalid model format: {model_format}")


### PR DESCRIPTION
This makes the expected model format explicit rather than implicit. 

This is important for users on the Pro or above plans, as they send multiple filters, and Flask doesn't support native nested objects.

Sadly, alternatives such as https://github.com/bernii/querystring-parser does not support arrays in nested objects, so while it can partially handle the necessary behavior, a custom parser is required to achieve the desired results. This will allow that addition to be added in a backward-compatible way by supporting a `"nested"` or equivalent model format in the future.

This defaults to `"json"` to maintain compatibility for users (though based on installs I don't think there are any yet)