### PR TITLE
0.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "mui-data-grid"
 packages = [{ include = "mui", from = "src" }]
 readme = "README.md"
 repository = "https://github.com/kkirsche/mui-data-grid"
-version = "0.8.0"
+version = "0.8.1"
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4"

--- a/src/mui/v5/integrations/sqlalchemy/sort/apply_item.py
+++ b/src/mui/v5/integrations/sqlalchemy/sort/apply_item.py
@@ -11,6 +11,11 @@ from mui.v5.integrations.sqlalchemy.resolver import Resolver
 
 
 def _no_operation(column: Any) -> None:
+    """Used when an unsorted operation is requested.
+
+    Returns:
+        None
+    """
     return None
 
 

--- a/src/mui/v5/integrations/sqlalchemy/sort/apply_model.py
+++ b/src/mui/v5/integrations/sqlalchemy/sort/apply_model.py
@@ -44,6 +44,12 @@ def apply_sort_to_query_from_model(
         # 1
         # 2
         # 3
-        *[get_sort_expression_from_item(item=item, resolver=resolver) for item in model]
+        *[
+            get_sort_expression_from_item(item=item, resolver=resolver)
+            for item in model
+            # if we don't skip item.sort None here, multiple order bys will cause
+            # an ORDER BY NULL, NULL clause instead of skipping the ORDER BY
+            if item.sort is not None
+        ]
     )
     return query

--- a/tests/mui/v5/integrations/sqlalchemy/sort/test_apply_model.py
+++ b/tests/mui/v5/integrations/sqlalchemy/sort/test_apply_model.py
@@ -57,6 +57,8 @@ def test_apply_sort_to_query_from_model_single_field(
     dir_str = _get_direction_str(direction=direction)
     if dir_str is not None:
         assert f"ORDER BY {ParentModel.__tablename__}.id {dir_str}" in compiled_str
+    else:
+        assert "ORDER BY" not in compiled_str
 
     sorted_results = sorted_query.all()
     row_count = sorted_query.count()
@@ -105,6 +107,8 @@ def test_apply_sort_to_query_from_model_multiple_fields(
         assert (
             f"ORDER BY {tbl}.grouping_id {dir_str}, {tbl}.id {dir_str}" in compiled_str
         )
+    else:
+        assert "ORDER BY" not in compiled_str
 
     sorted_results = sorted_query.all()
     row_count = sorted_query.count()


### PR DESCRIPTION
fix: `ORDER BY NULL, NULL` triggered when multiple unsorted columns are sent
chore: bump version to 0.8.1