### PR TITLE
relax typing for sqla2/14 compatibility

### DIFF
--- a/src/mui/v5/integrations/sqlalchemy/filter/apply_items.py
+++ b/src/mui/v5/integrations/sqlalchemy/filter/apply_items.py
@@ -4,7 +4,6 @@ from typing import Any, Callable, TypeVar
 
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Query
-from sqlalchemy.sql.elements import BooleanClauseList
 
 from mui.v5.grid import GridFilterItem, GridFilterModel, GridLinkOperator
 from mui.v5.integrations.sqlalchemy.filter.applicators import (
@@ -30,7 +29,7 @@ _Q = TypeVar("_Q")
 
 def _get_link_operator(
     model: GridFilterModel,
-) -> Callable[[Any], BooleanClauseList[Any]]:
+) -> Callable[[Any], Any]:
     """Retrieves the correct filter operator for a model.
 
     If the link operator is None, `AND` is used by default.
@@ -39,8 +38,13 @@ def _get_link_operator(
         model (GridFilterModel): The grid filter model which is being applied to the
             SQLAlchemy query.
 
-    Returns:
+    Returns SQLAlchemy V14:
+
         Callable[[Any], BooleanClauseList[Any]]: The `or_` and `and_` operators for
+            application to SQLAlchemy filters.
+
+    Returns SQLAlchemy V2+:
+        Callable[[Any], ColumnElement[bool]]: The `or_` and `and_` operators for
             application to SQLAlchemy filters.
     """
     if model.link_operator is None or model.link_operator == GridLinkOperator.And:

--- a/src/mui/v6/integrations/sqlalchemy/filter/apply_items.py
+++ b/src/mui/v6/integrations/sqlalchemy/filter/apply_items.py
@@ -4,7 +4,6 @@ from typing import Any, Callable, TypeVar
 
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Query
-from sqlalchemy.sql.elements import BooleanClauseList
 
 from mui.v6.grid import GridFilterItem, GridFilterModel, GridLogicOperator
 from mui.v6.integrations.sqlalchemy.filter.applicators import (
@@ -30,7 +29,7 @@ _Q = TypeVar("_Q")
 
 def _get_link_operator(
     model: GridFilterModel,
-) -> Callable[[Any], BooleanClauseList[Any]]:
+) -> Callable[[Any], Any]:
     """Retrieves the correct filter operator for a model.
 
     If the link operator is None, `AND` is used by default.
@@ -39,8 +38,13 @@ def _get_link_operator(
         model (GridFilterModel): The grid filter model which is being applied to the
             SQLAlchemy query.
 
-    Returns:
+    Returns SQLAlchemy V14:
+
         Callable[[Any], BooleanClauseList[Any]]: The `or_` and `and_` operators for
+            application to SQLAlchemy filters.
+
+    Returns SQLAlchemy V2+:
+        Callable[[Any], ColumnElement[bool]]: The `or_` and `and_` operators for
             application to SQLAlchemy filters.
     """
     if model.logic_operator is None or model.logic_operator == GridLogicOperator.And:


### PR DESCRIPTION
Was doing some testing with sqla2 and things look pretty good except that SQLA2 has changed the type of and_ and or_.  

In mui.v5/6.integrations.sqlalchemy.filter.apply_items, the _get_link_operator method looks like this:

```
def _get_link_operator(
    model: GridFilterModel,
) -> Callable[[Any], BooleanClauseList[Any]]:
```

With SQLA 2 it needs to change to this:

```
def _get_link_operator(
    model: GridFilterModel,
) -> Callable[[Any], ColumnElement[bool]]:
```

For compatibility with both, may need to back-off on the strictness and use this:

```
def _get_link_operator(
    model: GridFilterModel,
) -> Callable[[Any], Any]:
```

As _get_link_operator is an internal method, I don't think we lose much by loosening the typing.